### PR TITLE
Fix/3 log grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,7 @@ Please document changes that haven't been officially released in the [Unreleased
 - Upgraded minimum required Python version to 3.7
 - Relaxed constraints on the ID formation
 - Removed ID pattern filtering - using trusty old RegEx instead
+
+### Fixed
+
+- Log file grouping now supports any tags used in the metadata tag

--- a/kalash/collectors.py
+++ b/kalash/collectors.py
@@ -47,7 +47,7 @@ def _collect_test_case_from_module(
                             and _id is not None:
 
                         suite.addTest(obj(
-                            funcname, _id, trigger
+                            funcname, _id, meta, trigger
                         ))
                         if _trigger.cli_config:
                             if _trigger.cli_config.what_if == \

--- a/kalash/doc/basic_usage.md
+++ b/kalash/doc/basic_usage.md
@@ -161,7 +161,11 @@ The logger can be configured using the following CLI switches:
 * `--log-dir` - base directory for logs
 * `--log-level` - Python's `logging` library log verbosity
 * `--log-format` - Python's `logging` library formatter string
-* `--group-by` - *not done yet*, grouping log files by metadata tags
+* `--group-by` - grouping log files by metadata tags
+
+By default logs are written to a `logs` folder in the current working directory. Each test case gets its separate folder and log files contained within start with a timestamp.
+
+If `--group-by` is used, those test case folders are grouped by any specified property from the metadata tag. For example `--group-by devices` will group test cases by the `devices` key. If `devices` is a single string e.g. `"cancombo"` the log tree will be `"logs/cancombo/TestCaseID/123456789_TestCaseID"`. If `devices` is a list, e.g. `["cancombo", "lincombo"]`, the log tree will be `"logs/cancombo_lincombo/TestCaseID/123456789_TestCaseID"`.
 
 ### JSON Schema
 

--- a/kalash/log.py
+++ b/kalash/log.py
@@ -4,7 +4,7 @@ import logging
 from typing import List, Optional, Set, Union, Callable
 
 from .utils import get_ts
-from .config import CliConfig, Meta
+from .config import CliConfig, Meta, OneOrList
 
 PathType = Union[os.PathLike, str]
 
@@ -51,7 +51,14 @@ def _make_log_tree_from_id(
     log_name = get_ts(sep='') + '_' + dir_name
     full_path = ""
     if groupby:
-        group_dir_name = getattr(meta, groupby)
+        _group_dir_name: OneOrList[str] = getattr(meta, groupby)
+        group_dir_name: Optional[str] = ""
+        if type(_group_dir_name) is list:
+            group_dir_name = "_".join(_group_dir_name)
+        elif type(_group_dir_name) is str:
+            group_dir_name = _group_dir_name
+        else:
+            group_dir_name = None
         group_dir_name = group_dir_name if group_dir_name else "unknown_group"
         full_path = os.path.join(dir_name, group_dir_name, log_name)
     else:

--- a/kalash/log.py
+++ b/kalash/log.py
@@ -4,7 +4,7 @@ import logging
 from typing import List, Optional, Set, Union, Callable
 
 from .utils import get_ts
-from .config import CliConfig
+from .config import CliConfig, Meta
 
 PathType = Union[os.PathLike, str]
 
@@ -29,6 +29,7 @@ def _create_tree_if_not_exists(path: PathType) -> None:
 def _make_log_tree_from_id(
     id: str,
     class_name: str,
+    meta: Meta,
     groupby: Optional[str] = None
 ):
     """Creates log tree structure representation based on the
@@ -46,12 +47,16 @@ def _make_log_tree_from_id(
         A `str` path to the target directory where logs will
             be stored.
     """
-    # LATER: improved grouping based on arbitrary keys from the meta tag
     dir_name = id + '_' + class_name
-    # PRODTEST_1234_test_something_TestSomething_0_cancombo
     log_name = get_ts(sep='') + '_' + dir_name
-    # 00000000_PRODTEST_1234_test_something_TestSomething_0_cancombo
-    return os.path.join(dir_name, log_name)
+    full_path = ""
+    if groupby:
+        group_dir_name = getattr(meta, groupby)
+        group_dir_name = group_dir_name if group_dir_name else "unknown_group"
+        full_path = os.path.join(dir_name, group_dir_name, log_name)
+    else:
+        full_path = os.path.join(dir_name, log_name)
+    return full_path
 
 
 def _make_trunk(
@@ -84,12 +89,13 @@ def _make_trunk(
 def _make_tree(
     id: str,
     class_name: str,
+    meta: Meta,
     log_base_path: Optional[PathType] = None,
     groupby: str = None
 ):
     """Combines `_make_trunk_` with `_make_log_tree_from_id`."""
     return _make_trunk(
-        _make_log_tree_from_id(id, class_name, groupby=groupby),
+        _make_log_tree_from_id(id, class_name, meta, groupby=groupby),
         log_base_path
     )
 
@@ -159,6 +165,7 @@ def register_logger(
 def get(
     id: str,
     class_name: str,
+    meta: Meta,
     config: CliConfig
 ) -> logging.Logger:
     """Creates or returns an existing `logging.Logger` instance
@@ -174,7 +181,7 @@ def get(
     Returns:
         Associated `logging.Logger` instance
     """
-    path = _make_tree(id, class_name, config.log_dir, config.group_by)
+    path = _make_tree(id, class_name, meta, config.log_dir, config.group_by)
 
     l = _get_logger_from_state(class_name)  # noqa: E741
 

--- a/kalash/test_case.py
+++ b/kalash/test_case.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 import unittest
 import logging
 
-from .config import CliConfig, Trigger
+from .config import CliConfig, Meta, Trigger
 from .log import get, close
 
 
@@ -45,6 +45,7 @@ class TestCase(unittest.TestCase):
         self,
         methodName: str,
         id: str,
+        meta: Meta,
         trigger: Optional[Trigger]
     ) -> None:
         super().__init__(methodName=methodName)
@@ -53,6 +54,7 @@ class TestCase(unittest.TestCase):
         self.log_base_path = cli_config.log_dir if cli_config else None
         self.groupby = cli_config.group_by if cli_config else None
         self.no_log_echo = cli_config.no_log_echo if cli_config else None
+        self.meta = meta
         self.trigger = trigger
 
         # inject logger:
@@ -61,6 +63,7 @@ class TestCase(unittest.TestCase):
                 self.logger = get(
                     id,
                     self.__class__.__name__,
+                    self.meta,
                     cli_config
                 )
             else:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -59,9 +59,9 @@ class TestKalash(TestCase):
     def test_logging(self):
         result, return_code = run_test_suite(*make_loader_and_trigger_object(CliConfig(
             "./tests/test_yamls/test_logging.yaml",
-            "logs", "device",
+            "logs", "devices",
             False, self._debug, False, False, fail_fast=True)))
-        self.assertEqual(len(glob.glob('logs/**/*.log')), 2)
+        self.assertEqual(len(glob.glob('logs/**/**/*.log')), 2)
 
     def _whatif_helper(self, subdirs: List[str] = []):
         test_scripts_dir = os.path.join(

--- a/tests/unit_tests/test_logging.py
+++ b/tests/unit_tests/test_logging.py
@@ -4,7 +4,7 @@ import os
 import glob
 import time
 
-from kalash.config import CliConfig
+from kalash.config import CliConfig, Meta
 from kalash.log import (_make_tree, _make_log_tree_from_id,
                         register_logger, _LOGGERS, get, close, close_all)
 
@@ -14,19 +14,30 @@ class TestLogging(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.testid = "000000001_Blah"
-        cls.log_path_pattern = \
-            r'000000001_Blah_TestLog[\\\/]\d+_000000001_Blah_TestLog'
-        cls.expected_log_path = 'logs/000000001_Blah_TestLog'
+        cls.log_path_pattern = lambda cls, group: \
+            r'000000001_Blah_TestLog[\\\/]' + group + r'[\\\/]\d+_000000001_Blah_TestLog'
+        cls.expected_log_path = f'logs/{cls.testid}_TestLog/000000001_Blah'
 
-    def test_grouping_path(self):
-        """Tests directory tree restructure based
-        on device category.
-        """
+    def test_grouping_devices(self):
+        """Tests directory tree restructure based on device category."""
+        device_group = "cancombo"
         path = _make_log_tree_from_id(
             self.testid,
-            "TestLog"
+            "TestLog",
+            Meta.from_yaml_obj({"id": self.testid, "devices": device_group}, CliConfig(None)),
+            "devices"
         )
-        self.assertRegex(path, self.log_path_pattern)
+        self.assertRegex(path, self.log_path_pattern(device_group))
+    
+    def test_grouping_(self):
+        use_cases = "PRODTEST-1234"
+        path = _make_log_tree_from_id(
+            self.testid,
+            "TestLog",
+            Meta.from_yaml_obj({"id": self.testid, "use_cases": use_cases}, CliConfig(None)),
+            "use_cases"
+        )
+        self.assertRegex(path, self.log_path_pattern(use_cases))
 
     def test_directory_tree(self):
         """Req:
@@ -39,7 +50,8 @@ class TestLogging(unittest.TestCase):
                 |-> test_some_other_script_1_param_set_1
                 |-> test_some_other_script_1_param_set_2
         """
-        _make_tree(self.testid, "TestLog", "logs")
+        meta = Meta(id=self.testid)
+        _make_tree(self.testid, "TestLog", meta, "logs", "id")
         if not os.path.exists(self.expected_log_path):
             self.fail('Target path for logs not created properly!')
 
@@ -52,6 +64,7 @@ class TestLogging(unittest.TestCase):
         logger = get(
             self.testid,
             "TestLog",
+            Meta(),
             CliConfig(
                 None,
                 log_dir='logs2',
@@ -62,10 +75,6 @@ class TestLogging(unittest.TestCase):
         close(logger)
         time.sleep(0.5)
         self.assertGreater(len(glob.glob('logs2/**/*.log')), 0)
-
-    @unittest.skip("Awaiting reimplementation of grouping")
-    def test_logfile_grouping(self):
-        pass
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/tests/unit_tests/test_logging.py
+++ b/tests/unit_tests/test_logging.py
@@ -28,8 +28,18 @@ class TestLogging(unittest.TestCase):
             "devices"
         )
         self.assertRegex(path, self.log_path_pattern(device_group))
-    
-    def test_grouping_(self):
+
+    def test_grouping_devices_list(self):
+        device_group = ["cancombo", "lincombo"]
+        path = _make_log_tree_from_id(
+            self.testid,
+            "TestLog",
+            Meta.from_yaml_obj({"id": self.testid, "devices": device_group}, CliConfig(None)),
+            "devices"
+        )
+        self.assertRegex(path, self.log_path_pattern("_".join(device_group)))
+
+    def test_grouping_use_cases(self):
         use_cases = "PRODTEST-1234"
         path = _make_log_tree_from_id(
             self.testid,


### PR DESCRIPTION
**List all Issues this Pull Request is meant to solve**:

- [x] Closes #3 

**Run through our contribution checklist**:

- [x] Have you read `kalash/doc/contributing.md`?
- [x] Have you added tests for the implemented feature/fixed bug?
- [x] Have you ran a full test suite (`nox -e test`)?
- [x] Have you checked if the test coverage is at least 85%? -> (#4 still open)
- [x] Have you ran code style check (`flake8`)?
- [x] Have you documented the change?
- [x] Have you updated `CHANGELOG.md`?

**Describe shortly the changes you have introduced**:
Now logs are group-able by any metadata tags.

**Add additional comments (if any)**:
N/A